### PR TITLE
Remove unnecessary JavaScript code to break out of container div

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,39 +15,11 @@ export default {
     FisheriesMap,
     FisheriesReport,
   },
-  mounted() {
-    this.fillWidth()
-    window.addEventListener('resize', this.fillWidth)
-  },
   computed: {
     ...mapGetters({
       reportIsVisible: 'reportIsVisible',
       error: 'error',
     }),
-  },
-  methods: {
-    fillWidth() {
-      let windowWidth = window.innerWidth
-      let scrollbarWidth =
-        window.innerWidth - document.documentElement.clientWidth
-      let containerDiv = document.querySelector('.container')
-      if (containerDiv != null) {
-        let containerWidth = containerDiv.offsetWidth
-        let appDiv = document.getElementById('app')
-        let style = window.getComputedStyle(containerDiv)
-        let paddingWidth = style.paddingLeft
-        containerWidth -= parseInt(paddingWidth) * 2 - scrollbarWidth
-        let marginStyle
-        if (windowWidth == containerWidth) {
-          marginStyle = '-' + paddingWidth
-        } else {
-          let marginWidth = (windowWidth - containerWidth) / 2
-          marginStyle = '-' + marginWidth + 'px'
-        }
-        appDiv.style.marginLeft = marginStyle
-        appDiv.style.marginRight = marginStyle
-      }
-    },
   },
 }
 </script>


### PR DESCRIPTION
Closes #17.

I have confirmed that it is possible to embed a full-width custom HTML block into WordPress using the Beaver Builder plugin (already in use on the Sea Grant website). So, there's no need for this JavaScript trick to break out of the WordPress container div.

To test as a standalone app, just make sure the app continues to work as expected. You'll also notice that there's a slight margin around the entire app (from the `body` element) that wasn't there before.