### PR TITLE
Check that fields exist before showing them in table on report view

### DIFF
--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -6,31 +6,39 @@
       <div v-for="fishery in orderedResults()" :key="fishery">
         <h3 v-html="fishery['name']"></h3>
         <table>
-          <tr>
+          <tr v-if="fishery['access']">
             <td>Access</td>
             <td v-html="accessDict[fishery['access']]"></td>
           </tr>
-          <tr>
+          <tr v-if="fishery['species']">
             <td>Species</td>
             <td v-html="speciesDict[fishery['species']]"></td>
           </tr>
-          <tr>
+          <tr v-if="fishery['gear']">
             <td>Gear</td>
             <td v-html="gearDict[fishery['gear']]"></td>
           </tr>
-          <tr>
+          <tr
+            v-if="
+              fishery['region'] && Object.keys(fishery['region']).length > 0
+            "
+          >
             <td>Region</td>
             <td v-html="joined(fishery['region'], regionDict)"></td>
           </tr>
-          <tr>
+          <tr v-if="fishery['code']">
             <td>CFEC code</td>
             <td v-html="fishery['code']"></td>
           </tr>
-          <tr>
+          <tr
+            v-if="
+              fishery['seasons'] && Object.keys(fishery['seasons']).length > 0
+            "
+          >
             <td>Seasons</td>
             <td v-html="joined(fishery['seasons'], seasonDict)"></td>
           </tr>
-          <tr>
+          <tr v-if="fishery['link']">
             <td>Link</td>
             <td>
               <a :href="fishery['link']"


### PR DESCRIPTION
Closes #10.

I've confirmed that every fishery has a value for every field currently. However, it seems likely that fishery content in WordPress could change over the next few years so that some fisheries are missing some fields. This PR handles this case by omitting table rows with no values on the report view.

I've tested this by literally (and temporarily) removing some values from some fisheries in the WordPress sandbox powering the REST API to confirm that it removes the corresponding table row in the app. To test this PR from the coding side, you can try commenting out some of the fishery properties in the fishery object here:

https://github.com/ua-snap/fishbiz-map/blob/empty_field_check/src/store.js#L35

And make sure the corresponding table row is removed in the fishery report.