### PR TITLE
Stop removing and recreating the map when showing/closing report

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <FisheriesMap v-if="!this.reportIsVisible && !this.error" />
+  <FisheriesMap v-show="!this.reportIsVisible && !this.error" />
   <FisheriesReport v-if="this.reportIsVisible && !this.error" />
   <div v-if="this.error" class="error">Failed to load fisheries map.</div>
 </template>


### PR DESCRIPTION
Closes #4.

Without this PR, if you load the app, click a marker, then click the "Back to map" button, you'll notice a brief moment where the Leaflet map initializes itself from scratch again. This PR fixes this behavior by using `v-show` instead of `v-if` when determining whether to show the map component. This is because `v-show` simply hides the component instead of destroying it entirely like `v-if` does. So, the map component doesn't need to recreate the map from scratch every time a report is opened & closed.