### PR TITLE
Fix filter and zoom out bug

### DIFF
--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -265,7 +265,6 @@ export default {
       if (this.markerBounds == undefined) {
         let markerBounds = this.markerFeatureGroup.getBounds().pad(0.05)
         this.$store.commit('setMarkerBounds', markerBounds)
-      } else {
         this.map.fitBounds(this.markerBounds)
         this.map.setMinZoom(this.map.getZoom())
       }


### PR DESCRIPTION
Closes #23.

To see what this PR fixes, load the app from the `main` branch, zoom in a couple times, and then choose a filter from the dropdown menu. The map will call `fitBounds` on the filtered markers and usually zoom back out automatically. This is not intentional and isn't great for the user experience either.

This PR fixes this problem by only calling `fitBounds` when the map component first renders.