### PR TITLE
Scale report div max-height to app div height to handle app height override

### DIFF
--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -57,7 +57,7 @@
 .report {
   margin: 0 2rem;
   text-align: left;
-  max-height: 900px;
+  max-height: 100%;
   overflow-y: auto;
   font-size: 16px;
   h1 {


### PR DESCRIPTION
Closes #33.

The only code change in this PR is that the scrollable report div max-height is no longer hard-coded at `900px`. By setting this to `100%` instead, it sets the max-height to the height of the parent app div (which also happens to be `900px` by default).

Why bother, you ask? It's possible to override the height of the app div through the WordPress Beaver Builder interface, and with this change everything in the app will now scale accordingly to whatever height is chosen, giving designers more control without any code changes.

To test:

- Make sure the app still renders a reasonable sized map in standalone development mode (`npm run serve`). This is the default `900px` height you are seeing.
- Check out https://snapsandbox.wpcomstaging.com/beaver-builder-fishbiz-map-2/ for an example of how the app scales when the height is manually overridden to `600px`. Click a marker with several fishery results and observe that the results don't spill outside the bottom of the app div.