### PR TITLE
Use Raleway font throughout app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,9 +25,11 @@ export default {
 </script>
 
 <style lang="scss">
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap');
 /* The #app div lives in WordPress, not Vue, so this cannot be scoped. */
 #app {
   height: 900px;
+  font-family: 'Raleway', sans-serif;
   .error {
     position: relative;
     top: 40%;

--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -73,6 +73,7 @@
 .filter {
   flex-basis: 20%;
   --vs-search-input-placeholder-color: #757575;
+  font-family: 'Raleway', sans-serif;
   &::placeholder {
     font-size: 14px;
   }

--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -60,9 +60,9 @@
   max-height: 900px;
   overflow-y: auto;
   font-size: 16px;
-  h1 {
-    margin-top: 20px;
-    margin-bottom: 10px;
+  h1,
+  h3 {
+    font-family: 'Raleway', sans-serif;
   }
   button {
     margin: 1rem 0;
@@ -73,7 +73,6 @@
     border-radius: 0.4rem;
     cursor: pointer;
     transition: all 0.3s;
-    font-family: Avenir, Helvetica, Arial, sans-serif;
     font-weight: 400;
     -webkit-touch-callout: none;
     -webkit-user-select: none;


### PR DESCRIPTION
Closes #32.

With this change, all buttons, dropdowns, and text on the report page should be using the Raleway font as requested in #32.