### PR TITLE
Update README to include missing CSS file, real S3 bucket, and remove WP Code Embed references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fishbiz-map
 
-The repo contains the Vue project for the FishBiz Alaska fisheries map. This project can be run as a standalone Vue application for development, but is ultimately compiled into a static site that is pulled into a WordPress page via the Code Embed plugin.
+The repo contains the Vue project for the FishBiz Alaska fisheries map. This project can be run as a standalone Vue application for development, but is ultimately compiled into a static site that is pulled into a WordPress page via a Beaver Builder HTML block.
 
 ## Installing dependencies
 
@@ -22,29 +22,26 @@ npm run build
 
 ### Hosting static files
 
-After building the application, the contents of the `dist` directory need to be hosted somewhere. We are using an S3 bucket for this currently, but ideally in the future we will find a way to host the files within the WordPress website itself.
-
-To push the files to our development S3 bucket from the AWS CLI:
+After building the application, the contents of the `dist` directory need to be hosted in an S3 bucket. To push the static files to the production fishbiz-map S3 bucket from the AWS CLI, run the following:
 
 ```
-aws s3 cp dist s3://wordpress-code-embed/ --acl public-read --recursive
+aws s3 cp dist s3://fishbiz-map/ --acl public-read --recursive
 ```
 
-### Incorporating into WordPress via Code Embed plugin
+### Incorporating into WordPress via Beaver Builder
 
-To incorporate the static files into a WordPress page via the Code Embed plugin, simply install the Code Embed plugin, create or edit a page, and add the following custom field:
-
-Name:
-
-`CODEMAP`
-
-Value:
+To incorporate the static files into a WordPress page via Beaver Builder, simply use Beaver Builder's HTML module to create an HTML block on the page where the app should appear. Set the content of the HTML block to:
 
 ```
 <div id="app"></div>
-<script defer="defer" src="https://wordpress-code-embed.s3.us-west-2.amazonaws.com/app.js"></script>
-<link href="https://wordpress-code-embed.s3.us-west-2.amazonaws.com/app.css" rel="stylesheet">
-<script defer="defer" src="https://wordpress-code-embed.s3.us-west-2.amazonaws.com/chunk-vendors.js"></script>
+<script defer="defer" src="https://fishbiz-map.s3.us-west-2.amazonaws.com/app.js"></script>
+<script defer="defer" src="https://fishbiz-map.s3.us-west-2.amazonaws.com/chunk-vendors.js"></script>
+<link href="https://fishbiz-map.s3.us-west-2.amazonaws.com/app.css" rel="stylesheet">
+<link href="https://fishbiz-map.s3.us-west-2.amazonaws.com/chunk-vendors.css" rel="stylesheet">
 ```
 
-Save and view the page, and the Alaska fisheries map should then load into the page.
+The height of the app can be changed from its default height by setting inline CSS on the app div, like this:
+
+```
+<div id="app" style="height: 600px;"></div>
+```


### PR DESCRIPTION
Closes #38.

The PR fixes up the README to:

- Remove references & instructions for the no-longer-used WP Code Embed plugin, and replace them with references & instructions for Beaver Builder instead.
- Add the missing `chunk-vendors.css` file to the HTML code snippet, which is necessary now that the app is using the Pure CSS library.
- Update the S3 bucket to the new, soon-to-be-production `fishbiz-map` S3 bucket.
- Add instructions on how to scale the height of the embedded app.

This PR does not change the name of the app div (#40), however. That will be done as a separate PR once this is merged.