### PR TITLE
Make filters stack vertically at narrow resolutions, and fix font and z-index

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
 
 <script>
 import 'purecss/build/pure.css'
+import 'purecss/build/grids-responsive.css'
 import FisheriesMap from './components/FisheriesMap.vue'
 import FisheriesReport from './components/FisheriesReport.vue'
 import { mapGetters } from 'vuex'

--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -47,7 +47,7 @@
         />
       </div>
       <div class="pure-u">
-        <button class="filter pure-button" @click="clearFilters">Clear</button>
+        <button class="filter pure-button" @click="clearFilters">Reset filters</button>
       </div>
     </div>
     <div class="map-wrapper">

--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="app-contents">
     <div class="filters pure-g">
-      <div class="pure-u-4-24 filter">
+      <div class="pure-u-md-4-24 pure-u-1 filter">
         <input
           type="text"
           class="filter"
@@ -10,7 +10,7 @@
           v-model="enteredString"
         />
       </div>
-      <div class="pure-u-4-24">
+      <div class="pure-u-md-4-24 pure-u-1">
         <DropdownFilter
           class="filter"
           placeholder="Region"
@@ -19,7 +19,7 @@
           :value="region"
         />
       </div>
-      <div class="pure-u-4-24">
+      <div class="pure-u-md-4-24 pure-u-1">
         <DropdownFilter
           class="filter"
           placeholder="Access"
@@ -28,7 +28,7 @@
           :value="access"
         />
       </div>
-      <div class="pure-u-4-24">
+      <div class="pure-u-md-4-24 pure-u-1">
         <DropdownFilter
           class="filter"
           placeholder="Species"
@@ -37,7 +37,7 @@
           :value="species"
         />
       </div>
-      <div class="pure-u-4-24">
+      <div class="pure-u-md-4-24 pure-u-1">
         <DropdownFilter
           class="filter"
           placeholder="Gear"
@@ -71,11 +71,13 @@
 <style lang="scss" scoped>
 input[type='text'].filter {
   width: 100%;
+  box-sizing: border-box;
   margin: 0;
   font-size: 110%;
-  padding: 4px;
+  padding: 4px 8px;
   position: relative;
   top: 1px;
+  font-family: 'Raleway', sans-serif;
 
   &::placeholder {
     color: #000;
@@ -88,6 +90,7 @@ input[type='text'].filter {
 #map {
   min-height: 150px;
   height: 75vh;
+  z-index: 500;
 }
 
 #noresults {


### PR DESCRIPTION
Closes #43.

This PR:

- Uses Pure CSS' responsive grid system to stack the filters vertically at narrow resolutions
- Reduces the z-index of the map to prevent the map's zoom controls from hovering overtop the expanded dropdown filter options
- Uses `box-sizing: border-box;` to make the text input the same width as the dropdown filters when stacked vertically, and also fixes the font of the text input to use Raleway like everything else

I've uploaded this branch to https://alaskaseagrant.org/fishbiz/fisheries-explorer/ to make testing more fruitful :pineapple: