### PR TITLE
Show report in sidebar in desktop mode and use opacity to show currently selected marker

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,8 @@
 <template>
-  <FisheriesMap v-show="!this.error" />
+  <FisheriesMap
+    v-show="!this.error"
+    :class="{ 'hidden-mobile': reportIsVisible }"
+  />
   <FisheriesReport v-if="this.reportIsVisible && !this.error" />
   <div v-if="this.error" class="error">Failed to load fisheries map.</div>
 </template>
@@ -31,13 +34,30 @@ export default {
 /* The #app div lives in WordPress, not Vue, so this cannot be scoped. */
 #fishbiz-map {
   font-family: 'Raleway', sans-serif;
-  @media (min-width: 1000px) {
+  /* Corresponds to Pure CSS' "md" min breakpoint. */
+  @media (min-width: 48em) {
     display: flex;
   }
   .error {
     position: relative;
     top: 40%;
     transform: translateY(-40%);
+  }
+}
+/* "pure-hidden-*" classes were removed from Pure CSS, so implement comparable
+   classes manually. See the following for more info and width breakpoints:
+   https://github.com/pure-css/pure/issues/326 */
+
+/* Corresponds to Pure CSS' "sm" max breakpoint. */
+@media (max-width: 47.938em) {
+  .hidden-mobile {
+    display: none;
+  }
+}
+/* Corresponds to Pure CSS' "md" min breakpoint. */
+@media (min-width: 48em) {
+  .hidden-desktop {
+    display: none;
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <FisheriesMap v-show="!this.reportIsVisible && !this.error" />
+  <FisheriesMap v-show="!this.error" />
   <FisheriesReport v-if="this.reportIsVisible && !this.error" />
   <div v-if="this.error" class="error">Failed to load fisheries map.</div>
 </template>
@@ -31,6 +31,9 @@ export default {
 /* The #app div lives in WordPress, not Vue, so this cannot be scoped. */
 #fishbiz-map {
   font-family: 'Raleway', sans-serif;
+  @media (min-width: 1000px) {
+    display: flex;
+  }
   .error {
     position: relative;
     top: 40%;

--- a/src/components/BackButton.vue
+++ b/src/components/BackButton.vue
@@ -1,0 +1,17 @@
+<template>
+  <button class="pure-button" @click="goBack">
+    <span class="hidden-mobile">Close sidebar</span>
+    <span class="hidden-desktop">Back to map</span>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'BackButton',
+  methods: {
+    goBack: function () {
+      this.$store.commit('closeReport')
+    },
+  },
+}
+</script>

--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -53,7 +53,6 @@
       </div>
     </div>
     <div class="map-wrapper">
-      &nbsp;
       <div
         v-show="markers == 'startup' || markers.length > 0"
         id="fishbiz-map--leaflet"
@@ -87,6 +86,10 @@ input[type='text'].filter {
     color: #000;
   }
 }
+.filters {
+  margin-bottom: 1rem;
+}
+
 .filter {
   margin: 1rem 1rem 0;
 }
@@ -193,6 +196,7 @@ export default {
       if (this.reportIsVisible == false) {
         setTimeout(() => {
           this.map.invalidateSize()
+          this.map.fitBounds(this.markerBounds)
         })
         this.markers.forEach(marker => {
           marker.setOpacity(1.0)
@@ -282,6 +286,7 @@ export default {
       })
       setTimeout(() => {
         this.map.invalidateSize()
+        this.map.setView(clickedMarker.getLatLng())
       })
     },
     textSearch: _.debounce(function () {

--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="report">
     <h1>{{ groupDict[selectedGroup] }} in {{ regionDict[selectedRegion] }}</h1>
-    <button class="pure-button" @click="goBack">Close Sidebar</button>
+    <BackButton />
     <div id="report" v-if="filteredFisheries[selectedRegion] != undefined">
       <div v-for="fishery in orderedResults()" :key="fishery">
         <h3 v-html="fishery['name']"></h3>
@@ -51,7 +51,7 @@
         </table>
       </div>
     </div>
-    <button class="pure-button" @click="goBack">Close Sidebar</button>
+    <BackButton />
   </div>
 </template>
 
@@ -62,7 +62,10 @@
   max-height: 100%;
   overflow-y: auto;
   font-size: 16px;
-  flex-basis: 50%;
+  /* Corresponds to Pure CSS' "md" min breakpoint. */
+  @media (min-width: 48em) {
+    flex-basis: 50%;
+  }
   h1,
   h3 {
     font-family: 'Raleway', sans-serif;
@@ -76,9 +79,13 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
+import BackButton from './BackButton.vue'
 
 export default {
   name: 'FisheriesReport',
+  components: {
+    BackButton,
+  },
   computed: {
     ...mapGetters({
       filteredFisheries: 'filteredFisheries',

--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="report">
     <h1>{{ groupDict[selectedGroup] }} in {{ regionDict[selectedRegion] }}</h1>
-    <button class="pure-button" @click="goBack">Back to map</button>
+    <button class="pure-button" @click="goBack">Close Sidebar</button>
     <div id="report" v-if="filteredFisheries[selectedRegion] != undefined">
       <div v-for="fishery in orderedResults()" :key="fishery">
         <h3 v-html="fishery['name']"></h3>
@@ -51,7 +51,7 @@
         </table>
       </div>
     </div>
-    <button class="pure-button" @click="goBack">Back to map</button>
+    <button class="pure-button" @click="goBack">Close Sidebar</button>
   </div>
 </template>
 
@@ -62,6 +62,7 @@
   max-height: 100%;
   overflow-y: auto;
   font-size: 16px;
+  flex-basis: 50%;
   h1,
   h3 {
     font-family: 'Raleway', sans-serif;


### PR DESCRIPTION
Closes #45.

This PR:

- Shows the fisheries report in a sidebar next to the map when the browser width is desktop sized.
- Hides the map and shows the fisheries report in a full-width div when the browser is mobile sized.
- Pans to the selected marker and reduces the opacity of non-selected markers when in desktop mode.

To test, try opening and closing a report with a narrow browser window vs. a wide browser window. I've also uploaded this work to https://alaskaseagrant.org/fishbiz/fisheries-explorer/ to see how it looks "in production".