### PR TITLE
Fix bug that was hiding filtered markers belonging to multiple regions

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -237,10 +237,14 @@ export default createStore({
             newFiltered[region][group] = _.filter(
               filtered[region][group],
               fishery => {
-                if (
-                  _.includes([undefined, null, 'all'], state[filterKey]) ||
-                  fishery[filterKey] == state[filterKey]
-                ) {
+                let filterNotSet = _.includes(
+                  [undefined, null, 'all'],
+                  state[filterKey]
+                )
+                let filterMatched =
+                  region == state[filterKey] &&
+                  _.includes(fishery[filterKey], state[filterKey])
+                if (filterNotSet || filterMatched) {
                   return true
                 }
               }


### PR DESCRIPTION
Closes #50.

This fixes the bug described in #50.

Some fisheries have multiple values for certain taxonomies. For example, there are a handful of fisheries that belong to multiple regions. The chunk of JavaScript code that filters fisheries by the selected dropdown value was doing an equals comparison (`==`) of the selected value vs. the value of the fishery. Instead, it should be doing an "Is this value in the array?" style check (`.includes(...)`).

This went undetected before because doing a `==` comparison of a string vs. an array with one element returns true if the one element matches the string, so most filter functionality just happened to work. This PR uses `.includes(...)` instead of `==` and cleans up the code a little bit too.

To test, choose "Yakutat" or "Prince William Sound" from the "Region" dropdown filter. If the "Other" species marker appears for these regions while filtering, this PR is working as intended.