### PR TITLE
Add fishery name, code, and seasons to text search results

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -254,29 +254,28 @@ export default createStore({
         filtered = _.cloneDeep(newFiltered)
       })
 
-      let textSearchKeys = [
-        'name',
-        'code',
-        'region',
-        'access',
-        'species',
-        'gear',
-        'seasons',
-      ]
-
-      // Use these to perform text search on human readable strings, not slugs
-      let dictLookups = {
-        region: getters.regionDict,
-        access: getters.accessDict,
-        species: getters.speciesDict,
-        gear: getters.gearDict,
-        seasons: getters.seasonDict,
-      }
-
       // Perform text search if a search string was entered
       if (state.searchString != undefined) {
         let searchString = state.searchString.toLowerCase()
-        newFiltered = {}
+
+        let textSearchKeys = [
+          'name',
+          'code',
+          'region',
+          'access',
+          'species',
+          'gear',
+          'seasons',
+        ]
+
+        // Use these to perform text search on human readable strings, not slugs
+        let dictLookups = {
+          region: getters.regionDict,
+          access: getters.accessDict,
+          species: getters.speciesDict,
+          gear: getters.gearDict,
+          seasons: getters.seasonDict,
+        }
 
         // If the provided search string matches one and only one region, save
         // this region for later to prevent fisheries belonging to multiple
@@ -292,6 +291,7 @@ export default createStore({
           matchedRegion = matchedRegions[0]
         }
 
+        newFiltered = {}
         Object.keys(filtered).forEach(region => {
           newFiltered[region] = {}
           Object.keys(filtered[region]).forEach(group => {


### PR DESCRIPTION
Closes #53.

This PR adds the following fields to the text search feature:

- Fishery name
- CFEC code
- Seasons

It also fixes a bug that I discovered in the process. The app had been searching machine name slugs of taxonomy terms, not their corresponding human readable strings. This caused problems when searching for taxonomy terms with spaces in them. For example, before this change, searching for "Bering Sea" returned nothing because the slug looks like `bering-sea` (hyphen, not space).

I've also added a chunk of code that prevents the map from showing the same fishery in multiple locations if you search for a precise location. For example, if you search for "Bering Sea" in the text input, you will see map markers for just the Bering Sea region even though the same fishery, with the same multiple location strings, would otherwise show up elsewhere on the map too. The search bar deals with locations like you would expect, and the same way that the old FishBiz map works.

To test, try using the search bar to search for the CFEC code, season, fishery location, or anything else you expect to work through the search bar.