### PR TITLE
Update VUE_APP_WORDPRESS_URL default to production WordPress URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VUE_APP_WORDPRESS_URL=https://snapsandbox.wpcomstaging.com
+VUE_APP_WORDPRESS_URL=https://alaskaseagrant.org


### PR DESCRIPTION
Closes #15.

The fisheries, taxonomies, relationships, and REST API cache are now in place on the production WordPress website, which means we can now point this app to the production URL (by default) and everything works as before.

To test, try running this app and make sure everything is working like before when the app was pointed to the sandbox WordPress REST API. Keep in mind that the Access, Species, and Gear dropdown filters are broken in this branch since they were fixed in PR #58 (pending review).