### PR TITLE
Add full-width label bar above filters to call attention to them

### DIFF
--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="app-contents">
+    <div v-show="!reportIsVisible" class="filter-label-bar">
+      &#8595;&nbsp;&nbsp;Fishery drop-down menus&nbsp;&nbsp;&#8595;
+    </div>
     <div v-show="!reportIsVisible" class="filters pure-g">
       <div class="pure-u-md-4-24 pure-u-1 filter">
         <input
@@ -72,6 +75,14 @@
 </template>
 
 <style lang="scss" scoped>
+.filter-label-bar {
+  font-size: 1.25rem;
+  text-align: center;
+  color: #425064;
+  background-color: #d5ebff;
+  padding: 10px;
+}
+
 input[type='text'].filter {
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Closes #61.

This adds a full-width "Fishery drop-down menus" (with downward arrows) label bar above the map filters to draw more attention to them, and to section them off from the rest of the Fisheries Explorer page. This bar shows only when the user is in the map view and the filters are visible, not the report view.

To test, verify that the "Fishery drop-down menus" bar shows when in map view on both desktop & mobile (stacked filters) mode, and disappears when you click a marker.