### PR TITLE
Add summary of unique species results to top of report

### DIFF
--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -2,6 +2,7 @@
   <div class="report">
     <h1>{{ groupDict[selectedGroup] }} in {{ regionDict[selectedRegion] }}</h1>
     <BackButton />
+    <p>The following species are listed below: {{ speciesSummary() }}</p>
     <div id="report" v-if="filteredFisheries[selectedRegion] != undefined">
       <div v-for="fishery in orderedResults()" :key="fishery">
         <h3 v-html="fishery['name']"></h3>
@@ -111,6 +112,16 @@ export default {
         this.filteredFisheries[this.selectedRegion][this.selectedGroup],
         'name'
       )
+    },
+    speciesSummary: function () {
+      let species = _.map(
+        this.filteredFisheries[this.selectedRegion][this.selectedGroup],
+        fishery => {
+          let slug = fishery['species']
+          return this.speciesDict[slug]
+        }
+      )
+      return _.uniq(species).sort().join(', ')
     },
   },
 }


### PR DESCRIPTION
Closes #63.

This PR adds a species summary at the top of the report view, summarizing the unique species that appear in the results tables below it.

To test, click a handful of markers and make sure all species that show in the report tables are represented in the summaries.