### PR TITLE
Increase font size of filter label bar to work better for WordPress page

### DIFF
--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -76,7 +76,7 @@
 
 <style lang="scss" scoped>
 .filter-label-bar {
-  font-size: 1.25rem;
+  font-size: 1.75rem;
   text-align: center;
   color: #425064;
   background-color: #d5ebff;


### PR DESCRIPTION
This PR increases the font size of the "Fishery drop-down menus" bar to work better for the WordPress page styling. That's all!