### PR TITLE
Add fish group description subtitles to report view

### DIFF
--- a/src/components/FisheriesReport.vue
+++ b/src/components/FisheriesReport.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="report">
     <h1>{{ groupDict[selectedGroup] }} in {{ regionDict[selectedRegion] }}</h1>
+    <p
+      class="subtitle"
+      v-if="subtitle(selectedGroup)"
+      v-html="subtitle(selectedGroup)"
+    />
     <BackButton />
     <div id="report" v-if="filteredFisheries[selectedRegion] != undefined">
       <div v-for="fishery in orderedResults()" :key="fishery">
@@ -70,6 +75,9 @@
   h3 {
     font-family: 'Raleway', sans-serif;
   }
+  .subtitle {
+    margin-bottom: 1.5rem;
+  }
   table {
     margin: -0.5rem 0 2rem;
   }
@@ -88,6 +96,7 @@ export default {
   },
   computed: {
     ...mapGetters({
+      groupSubtitles: 'groupSubtitles',
       filteredFisheries: 'filteredFisheries',
       selectedRegion: 'selectedRegion',
       selectedGroup: 'selectedGroup',
@@ -102,6 +111,11 @@ export default {
   methods: {
     goBack: function () {
       this.$store.commit('closeReport')
+    },
+    subtitle: function (group) {
+      if (_.has(this.groupSubtitles, group)) {
+        return this.groupSubtitles[group]
+      }
     },
     joined: function (array, dict) {
       return _.map(array, key => dict[key]).join(', ')

--- a/src/store.js
+++ b/src/store.js
@@ -215,6 +215,17 @@ export default createStore({
   },
 
   getters: {
+    groupSubtitles() {
+      return {
+        crab: 'The crab category includes dungeness, king, tanner, and other crab.',
+        finfish:
+          'The finfish category includes herring, salmon, and other freshwater finfish.',
+        'ground-fish':
+          'The groundfish category includes halibut, Pacific cod, pollock, rockfish, and sablefish.',
+        'other-species':
+          'The other species category includes clams, geoducks, octopuses, scallops, sea urchins, snails, and squid.',
+      }
+    },
     regions(state) {
       return state.regions
     },


### PR DESCRIPTION
Closes #68.

This PR simply adds a subtitle to the report view to indicate what species are included in the selected fish group, not necessarily what species are present in the results. To test, all fish groups except the shrimp group should have a subtitle that lists the species that are included in the group, borrowed from the marker key higher up the page here:

https://alaskaseagrant.org/fishbiz/fisheries-explorer/

Shrimp are just shrimp.