### PR TITLE
Increase unfocused marker opacity to 50%

### DIFF
--- a/src/components/FisheriesMap.vue
+++ b/src/components/FisheriesMap.vue
@@ -351,7 +351,7 @@ export default {
       })
       this.markers.forEach(marker => {
         if (marker._leaflet_id != clickedMarker._leaflet_id) {
-          marker.setOpacity(0.2)
+          marker.setOpacity(0.5)
         } else {
           marker.setOpacity(1.0)
         }


### PR DESCRIPTION
Closes #69.

To test, click a marker and notice how the other markers are more opaque than before, and easily distinguishable over land.